### PR TITLE
Fix NoSQL injection risks in services

### DIFF
--- a/config/db.ts
+++ b/config/db.ts
@@ -15,7 +15,8 @@ module.exports = async () => {
         try {
             await mongoose.connect(DB_URI, {
                 useNewUrlParser: true,
-                useUnifiedTopology: true
+                useUnifiedTopology: true,
+                sanitizeFilter: true
             });
             console.log('Conexión correcta a la base de datos');
         } catch (err) {

--- a/src/helpers/sanitize.ts
+++ b/src/helpers/sanitize.ts
@@ -1,0 +1,12 @@
+export function sanitize(obj: any): any {
+  if (obj && typeof obj === 'object') {
+    for (const key of Object.keys(obj)) {
+      if (key.startsWith('$') || key.includes('.')) {
+        delete obj[key];
+      } else {
+        obj[key] = sanitize(obj[key]);
+      }
+    }
+  }
+  return obj;
+}

--- a/src/servicios/cosecha.service.ts
+++ b/src/servicios/cosecha.service.ts
@@ -1,5 +1,6 @@
 import Cosecha, { ICosecha } from '../models/cosecha';
 import Cultivo from '../models/Cultivo';
+import { sanitize } from '../helpers/sanitize';
 
 class CosechaService {
   public async getAllCosechas(idEmpresa: string): Promise<ICosecha[]> {
@@ -11,7 +12,8 @@ class CosechaService {
   }
 
   public async createCosecha(data: Partial<ICosecha>, idEmpresa: string): Promise<ICosecha> {
-    const { cultivo, cantidadCosechada, unidad, observaciones } = data;
+    const clean = sanitize({ ...data }) as Partial<ICosecha>;
+    const { cultivo, cantidadCosechada, unidad, observaciones } = clean;
   
     // Validar que el cultivo pertenece a la empresa
     const cultivoExiste = await Cultivo.findOne({ _id: cultivo, empresa: idEmpresa });
@@ -36,9 +38,10 @@ class CosechaService {
     const actual = await Cosecha.findOne({ _id: id, empresa: idEmpresa });
     if (!actual) throw new Error('Cosecha no encontrada o no pertenece a la empresa');
 
+    const clean = sanitize({ ...data }) as Partial<ICosecha>;
     const updateData = {
-      ...data,
-      cultivo: data.cultivo ?? actual.cultivo,
+      ...clean,
+      cultivo: clean.cultivo ?? actual.cultivo,
     };
 
     return Cosecha.findByIdAndUpdate(id, updateData, { new: true });

--- a/src/servicios/cultivo.service.ts
+++ b/src/servicios/cultivo.service.ts
@@ -1,6 +1,7 @@
 import Cultivo, { ICultivo } from '../models/Cultivo';
 import Semilla from '../models/semilla';
 import Parcela from '../models/parcela';
+import { sanitize } from '../helpers/sanitize';
 
 class CultivoService {
   public async getAllCultivos(idEmpresa: string): Promise<ICultivo[]> {
@@ -12,7 +13,8 @@ class CultivoService {
   }
 
   public async createCultivo(data: Partial<ICultivo>, idEmpresa: string): Promise<ICultivo> {
-    const { semilla, parcela, cantidadSemilla, unidad, fechaSiembra, fechaCosecha } = data;
+    const clean = sanitize({ ...data }) as Partial<ICultivo>;
+    const { semilla, parcela, cantidadSemilla, unidad, fechaSiembra, fechaCosecha } = clean;
 
     // Validar existencia de semilla y parcela dentro de la empresa
     const semillaExiste = await Semilla.findOne({ _id: semilla, empresa: idEmpresa });
@@ -38,16 +40,17 @@ class CultivoService {
 
   public async updateCultivo(id: string, data: Partial<ICultivo>, idEmpresa: string): Promise<ICultivo | null> {
     const cultivoActual = await Cultivo.findOne({ _id: id, empresa: idEmpresa });
-  
+    
     if (!cultivoActual) {
       throw new Error('Cultivo no encontrado o no pertenece a la empresa');
     }
-  
+
     // Si no se manda semilla o parcela, mantener las actuales
+    const clean = sanitize({ ...data }) as Partial<ICultivo>;
     const updateData = {
-      ...data,
-      semilla: data.semilla ?? cultivoActual.semilla,
-      parcela: data.parcela ?? cultivoActual.parcela,
+      ...clean,
+      semilla: clean.semilla ?? cultivoActual.semilla,
+      parcela: clean.parcela ?? cultivoActual.parcela,
     };
   
     const actualizado = await Cultivo.findByIdAndUpdate(id, updateData, { new: true });

--- a/src/servicios/empresa.service.ts
+++ b/src/servicios/empresa.service.ts
@@ -2,16 +2,18 @@ import { Types } from 'mongoose';
 import Empresa, { IEmpresa } from '../models/empresa';
 import Usuario from '../models/usuario';
 import { semillaService } from './semilla.service';
+import { sanitize } from '../helpers/sanitize';
 
 class EmpresaService {
 
   public async createEmpresa(data: IEmpresa): Promise<IEmpresa> { // funciona
-    if (typeof data.nombreEmpresa !== 'string') {
+    const clean = sanitize({ ...data }) as IEmpresa;
+    if (typeof clean.nombreEmpresa !== 'string') {
       throw new Error('Los datos de entrada son inválidos');
     }
 
     try {
-      const empresaCreada: IEmpresa = await Empresa.create(data);
+      const empresaCreada: IEmpresa = await Empresa.create(clean);
       return empresaCreada;
     } catch (error: any) {
       throw new Error(error.message || 'Error al crear la empresa');
@@ -19,12 +21,13 @@ class EmpresaService {
   }
 
   public async updateEmpresa(id: string, data: Partial<IEmpresa>): Promise<IEmpresa | null> { // funciona
-    if (!data.nombreEmpresa || typeof data.nombreEmpresa !== 'string') {
+    const clean = sanitize({ ...data }) as Partial<IEmpresa>;
+    if (!clean.nombreEmpresa || typeof clean.nombreEmpresa !== 'string') {
       throw new Error('El nombre de la empresa es obligatorio y debe ser un string');
     }
 
     try {
-      const empresaActualizada = await Empresa.findByIdAndUpdate(id, data, { new: true });
+      const empresaActualizada = await Empresa.findByIdAndUpdate(id, clean, { new: true });
 
       if (!empresaActualizada) {
         throw new Error('Empresa no encontrada');

--- a/src/servicios/login.service.ts
+++ b/src/servicios/login.service.ts
@@ -1,6 +1,7 @@
 import Usuario from '../models/usuario';
 import { InvalidCredentialsError, UsuarioEliminadoError } from '../errors/loginErrors';
 import {  UsuarioGoogleError } from '../errors/usuarioErrors';
+import { sanitize } from '../helpers/sanitize';
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
 
@@ -8,8 +9,10 @@ class LoginService {
 
     public async loguear(email: string, contraseña: string) { // funciona
         try {
+            const cleanEmail = sanitize(email);
+            const cleanPass = sanitize(contraseña);
             // Buscar usuario por email
-            const user = await Usuario.findOne({ email });
+            const user = await Usuario.findOne({ email: cleanEmail });
             if (!user) {
                 throw new InvalidCredentialsError();
             }
@@ -22,7 +25,7 @@ class LoginService {
             }
 
             // Comparar contraseñas
-            const passwordCorrect = await bcrypt.compare(contraseña, user.contraseña);
+            const passwordCorrect = await bcrypt.compare(cleanPass, user.contraseña);
             if (!passwordCorrect) {
                 throw new InvalidCredentialsError();
             }
@@ -64,7 +67,8 @@ class LoginService {
                 throw new UsuarioEliminadoError();
             }
 
-            const passwordCorrect = await bcrypt.compare(contraseña, user.contraseña);
+            const cleanPass = sanitize(contraseña);
+            const passwordCorrect = await bcrypt.compare(cleanPass, user.contraseña);
             if (!passwordCorrect) {
                 throw new InvalidCredentialsError();
             }

--- a/src/servicios/parcela.service.ts
+++ b/src/servicios/parcela.service.ts
@@ -1,4 +1,5 @@
 import Parcela, { IParcela } from '../models/parcela';
+import { sanitize } from '../helpers/sanitize';
 
 class ParcelaService {
 
@@ -11,8 +12,9 @@ class ParcelaService {
   }
 
   public async createParcela(data: Partial<IParcela>, idEmpresa: string): Promise<IParcela> {
+    const clean = sanitize({ ...data }) as Partial<IParcela>;
     const nuevaParcela = new Parcela({
-      ...data,
+      ...clean,
       estado: true,
       empresa: idEmpresa,
     });
@@ -21,9 +23,10 @@ class ParcelaService {
   }
 
   public async updateParcela(id: string, data: Partial<IParcela>, idEmpresa: string): Promise<IParcela | null> {
+    const clean = sanitize({ ...data }) as Partial<IParcela>;
     const actualizada = await Parcela.findOneAndUpdate(
       { _id: id, empresa: idEmpresa },
-      data,
+      clean,
       { new: true }
     );
 

--- a/src/servicios/precios.service.ts
+++ b/src/servicios/precios.service.ts
@@ -1,21 +1,25 @@
 import Price from '../models/precios';
+import { sanitize } from '../helpers/sanitize';
 
 class PreciosService {
 public async savePrice(doc: { symbol: string; price: number; ts: Date }) {
+  const clean = sanitize({ ...doc }) as { symbol: string; price: number; ts: Date };
   // Evita duplicar dentro de la misma ventana de 40 min
   return Price.findOneAndUpdate(
-    { symbol: doc.symbol, ts: { $lte: doc.ts, $gte: new Date(doc.ts.getTime() - 40 * 60000) } },
-    doc,
+    { symbol: clean.symbol, ts: { $lte: clean.ts, $gte: new Date(clean.ts.getTime() - 40 * 60000) } },
+    clean,
     { upsert: true, new: true }
   );
 }
 
 public async getLatest(symbol: string) {
-  return Price.findOne({ symbol }).sort({ ts: -1 }).lean();
+  const cleanSymbol = sanitize(symbol) as string;
+  return Price.findOne({ symbol: cleanSymbol }).sort({ ts: -1 }).lean();
 }
 
 public async getHistory(symbol: string, limit = 100) {
-  return Price.find({ symbol }).sort({ ts: -1 }).limit(limit).lean();
+  const cleanSymbol = sanitize(symbol) as string;
+  return Price.find({ symbol: cleanSymbol }).sort({ ts: -1 }).limit(limit).lean();
 }
 
 }

--- a/src/servicios/semilla.service.ts
+++ b/src/servicios/semilla.service.ts
@@ -1,4 +1,5 @@
 import Semilla, { ISemilla } from '../models/semilla';
+import { sanitize } from '../helpers/sanitize';
 
 class SemillaService {
   public async getAllSemillas(idEmpresa: string): Promise<ISemilla[]> {
@@ -10,9 +11,10 @@ class SemillaService {
   }
 
   public async updateSemilla(id: string, data: Partial<ISemilla>, idEmpresa: string): Promise<ISemilla | null> {
+    const clean = sanitize({ ...data }) as Partial<ISemilla>;
     const semilla = await Semilla.findOneAndUpdate(
       { _id: id, empresa: idEmpresa },
-      data,
+      clean,
       { new: true }
     );
 

--- a/src/servicios/usuario.service.ts
+++ b/src/servicios/usuario.service.ts
@@ -5,12 +5,16 @@ import { UsuarioExistenteError } from "../errors/usuarioErrors";
 import { empresaService } from '../servicios/empresa.service';
 import { semillaService } from '../servicios/semilla.service';
 import { inviteCodeService } from '../servicios/inviteCodes.service';
+import { sanitize } from '../helpers/sanitize';
 const bcrypt = require('bcrypt');
 
 class UsuarioService {
 
   public async registrarse(nuevousuario: IUsuario, codigoInvitacion?: string, empresaData?: IEmpresa): Promise<IUsuario> {
-    if (await Usuario.exists({ email: nuevousuario.email })) {
+    const cleanUser = sanitize({ ...nuevousuario }) as IUsuario;
+    const cleanEmpresa = empresaData ? sanitize({ ...empresaData }) as IEmpresa : undefined;
+
+    if (await Usuario.exists({ email: cleanUser.email })) {
         throw new UsuarioExistenteError();
     }
 
@@ -28,8 +32,9 @@ class UsuarioService {
         nuevousuario.administrador = false;
     } else if (empresaData) {
         // Si está creando una empresa nueva, asignar fecha de creación y registrar la empresa
-        empresaData.fechaCreacion = new Date();
-        empresa = await empresaService.createEmpresa(empresaData);
+        if (!cleanEmpresa) throw new UsuarioExistenteError("Faltan datos para empresa");
+        cleanEmpresa.fechaCreacion = new Date();
+        empresa = await empresaService.createEmpresa(cleanEmpresa);
         
         // Crear semillas base con stock 0
         await semillaService.crearSemillasBase(empresa._id);
@@ -41,10 +46,10 @@ class UsuarioService {
     }
 
     // Hashear la contraseña antes de guardar
-    nuevousuario.contraseña = await bcrypt.hash(nuevousuario.contraseña, 8);
-    nuevousuario.empresa = empresa._id;
+    cleanUser.contraseña = await bcrypt.hash(cleanUser.contraseña, 8);
+    cleanUser.empresa = empresa._id;
 
-    return await Usuario.create(nuevousuario);
+    return await Usuario.create(cleanUser);
   }
 
   public async deleteUsuario(id: string): Promise<IUsuario | null> {
@@ -91,11 +96,12 @@ class UsuarioService {
         }
 
         // Verificar qué campos se actualizarán
-        if (datosActualizados.nombre !== undefined) {
-            usuario.nombre = datosActualizados.nombre;
+        const clean = sanitize({ ...datosActualizados }) as Partial<IUsuario>;
+        if (clean.nombre !== undefined) {
+            usuario.nombre = clean.nombre;
         }
-        if (datosActualizados.apellido !== undefined) {
-            usuario.apellido = datosActualizados.apellido;
+        if (clean.apellido !== undefined) {
+            usuario.apellido = clean.apellido;
         }
 
         // Guardar los cambios
@@ -121,8 +127,9 @@ class UsuarioService {
         }
 
         // Verificar qué campos se actualizarán
-        if (datosActualizados.contraseña !== undefined) {
-            usuario.contraseña = await bcrypt.hash(datosActualizados.contraseña, 8);
+        const clean = sanitize({ ...datosActualizados }) as Partial<IUsuario>;
+        if (clean.contraseña !== undefined) {
+            usuario.contraseña = await bcrypt.hash(clean.contraseña, 8);
             console.log(usuario.contraseña);
         }  else{
           
@@ -171,9 +178,10 @@ class UsuarioService {
   }
 
   public async setExpoToken(id: string, token: string) {
+    const cleanToken = sanitize(token) as string;
     const usuario = await Usuario.findByIdAndUpdate(
       id,
-      { expoToken: token },
+      { expoToken: cleanToken },
       { new: true }
     );
     if (!usuario) {
@@ -183,12 +191,12 @@ class UsuarioService {
   }
 
   public async deleteUsuarioDeMiEmpresa(idAdmin: string, idUsuario: string): Promise<IUsuario> {
-    const admin = await Usuario.findById(idAdmin);
+    const admin = await Usuario.findById(sanitize(idAdmin));
     if (!admin || !admin.administrador) {
       throw new Error('No autorizado: solo administradores pueden realizar esta acción');
     }
-  
-    const usuario = await Usuario.findById(idUsuario);
+
+    const usuario = await Usuario.findById(sanitize(idUsuario));
     if (!usuario) {
       throw new Error('Usuario a reasignar no encontrado');
     }


### PR DESCRIPTION
## Summary
- add a sanitize helper
- enable mongoose `sanitizeFilter` in DB connection
- sanitize inputs for create/update operations in services

## Testing
- `npm run tsc` *(fails: cannot find module './Cultivo')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846dca21e0c8326a644cf7e16b296cd