### PR TITLE
Ensure all controllers throw errors through handler

### DIFF
--- a/src/controllers/cultivo.controller.ts
+++ b/src/controllers/cultivo.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { cultivoService } from '../services/cultivo.service';
+import { HttpError } from '../errors/HttpError';
 
 class CultivoController {
   public async getAllCultivos(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -25,8 +26,7 @@ class CultivoController {
       const empresaId = req.user?.idEmpresa;
 
       if (!empresaId) {
-        res.status(401).json({ error: 'ID de empresa no encontrado en el token' });
-        return;
+        return next(new HttpError(401, 'ID de empresa no encontrado en el token'));
       }
 
       const cultivo = await cultivoService.createCultivo(req.body, empresaId);
@@ -50,8 +50,7 @@ class CultivoController {
       const eliminado = await cultivoService.deleteCultivo(req.params.id, req.user.idEmpresa);
 
       if (!eliminado) {
-        res.status(404).json({ message: 'Cultivo no encontrado' });
-        return;
+        return next(new HttpError(404, 'Cultivo no encontrado'));
       }
 
       res.status(200).json({

--- a/src/controllers/empresa.controller.ts
+++ b/src/controllers/empresa.controller.ts
@@ -1,35 +1,36 @@
 import { Request, Response, NextFunction } from 'express';
 import { empresaService } from '../services/empresa.service';
+import { HttpError } from '../errors/HttpError';
 
 class EmpresaController {
 
-  public async updateEmpresa(req: Request, res: Response): Promise<Response> {
+  public async updateEmpresa(req: Request, res: Response, next: NextFunction): Promise<Response | void> {
     const idEmpresa = req.user?.idEmpresa;
 
     if (!idEmpresa) {
-      return res.status(400).json({ error: 'ID de empresa no encontrado en el token' });
+      return next(new HttpError(400, 'ID de empresa no encontrado en el token'));
     }
 
     try {
       const empresaActualizada = await empresaService.updateEmpresa(idEmpresa, req.body);
       return res.status(200).json(empresaActualizada);
     } catch (error: any) {
-      return res.status(400).json({ error: error.message });
+      next(error);
     }
   }
 
-  public async getNombreEmpresa(req: Request, res: Response): Promise<Response> {
+  public async getNombreEmpresa(req: Request, res: Response, next: NextFunction): Promise<Response | void> {
     const idEmpresa = req.user?.idEmpresa;
 
     if (!idEmpresa) {
-      return res.status(400).json({ error: 'ID de empresa no encontrado en el token' });
+      return next(new HttpError(400, 'ID de empresa no encontrado en el token'));
     }
 
     try {
       const nombre = await empresaService.getNombreEmpresa(idEmpresa);
       return res.status(200).json({ nombreEmpresa: nombre });
     } catch (error: any) {
-      return res.status(500).json({ error: error.message || 'Error al obtener el nombre de la empresa' });
+      next(error);
     }
   }
 
@@ -38,13 +39,13 @@ class EmpresaController {
       const idEmpresa = req.user?.idEmpresa;
 
       if (!idEmpresa) {
-        return res.status(400).json({ message: 'ID de empresa no encontrado en el token' });
+        return next(new HttpError(400, 'ID de empresa no encontrado en el token'));
       }
 
       const empresaEliminada = await empresaService.deleteEmpresa(idEmpresa);
 
       if (!empresaEliminada) {
-        return res.status(404).json({ message: 'Empresa no encontrada' });
+        return next(new HttpError(404, 'Empresa no encontrada'));
       }
 
       return res.status(200).json({
@@ -56,24 +57,28 @@ class EmpresaController {
     }
   }
 
-  public async crearEmpresaDesdeGoogle(req: Request, res: Response): Promise<Response> {
+  public async crearEmpresaDesdeGoogle(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> {
     const idEmpresaActual = req.user?.idEmpresa;
     const idEmpresaFicticia = '6840da01ba52fec6d68de6bc';
 
     if (!idEmpresaActual || idEmpresaActual !== idEmpresaFicticia) {
-      return res.status(403).json({ error: 'No autorizado para crear empresa desde esta ruta' });
+      return next(new HttpError(403, 'No autorizado para crear empresa desde esta ruta'));
     }
 
     const { nombreEmpresa } = req.body;
     if (!nombreEmpresa || typeof nombreEmpresa !== 'string') {
-      return res.status(400).json({ error: 'nombreEmpresa es requerido y debe ser string' });
+      return next(new HttpError(400, 'nombreEmpresa es requerido y debe ser string'));
     }
 
     try {
       const nuevaEmpresa = await empresaService.crearEmpresaDesdeGoogle(nombreEmpresa, req.user.id);
       return res.status(201).json({ empresa: nuevaEmpresa });
     } catch (error: any) {
-      return res.status(500).json({ error: error.message || 'Error al crear empresa desde Google' });
+      next(error);
     }
   }
   

--- a/src/controllers/parcela.controller.ts
+++ b/src/controllers/parcela.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { parcelaService } from '../services/parcela.service';
+import { HttpError } from '../errors/HttpError';
 
 class ParcelaController {
   public async getAllParcelas(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -25,8 +26,7 @@ class ParcelaController {
       const empresaId = req.user?.idEmpresa;
   
       if (!empresaId) {
-        res.status(401).json({ error: 'ID de empresa no encontrado en el token' });
-        return;
+        return next(new HttpError(401, 'ID de empresa no encontrado en el token'));
       }
   
       const parcela = await parcelaService.createParcela(req.body, empresaId);
@@ -51,15 +51,13 @@ class ParcelaController {
       const parcelaId = req.params.id;
   
       if (!idEmpresa) {
-        res.status(400).json({ message: 'ID de empresa no encontrado en el token' });
-        return;
+        return next(new HttpError(400, 'ID de empresa no encontrado en el token'));
       }
   
       const parcelaEliminada = await parcelaService.deleteParcela(parcelaId, idEmpresa);
   
       if (!parcelaEliminada) {
-        res.status(404).json({ message: 'Parcela no encontrada' });
-        return;
+        return next(new HttpError(404, 'Parcela no encontrada'));
       }
   
       res.status(200).json({

--- a/src/controllers/precios.controller.ts
+++ b/src/controllers/precios.controller.ts
@@ -1,11 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 import { preciosService } from '../services/precios.service';
+import { HttpError } from '../errors/HttpError';
 
 export async function latest(req: Request, res: Response, next: NextFunction) {
   try {
     const { symbol } = req.params;
     const doc = await preciosService.getLatest(symbol.toUpperCase());
-    if (!doc) return res.status(404).json({ error: 'not found' });
+    if (!doc) return next(new HttpError(404, 'not found'));
     res.json(doc);
   } catch (err) {
     next(err);

--- a/src/errors/HttpError.ts
+++ b/src/errors/HttpError.ts
@@ -1,0 +1,8 @@
+export class HttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'HttpError';
+  }
+}

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { HttpError } from '../errors/HttpError';
 
 const ERROR_HANDLERS = {
   JsonWebTokenError: (res: Response) =>
@@ -43,9 +44,22 @@ const ERROR_HANDLERS = {
   },
 };
 
-module.exports = (error: Error, _req: Request, res: Response, _next: NextFunction) => {
+module.exports = (
+  error: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) => {
+  // Log every error for troubleshooting
+  console.error(error);
+
+  if (error instanceof HttpError) {
+    return res.status(error.status).json({ error: error.message });
+  }
+
   const handler =
-    ERROR_HANDLERS[error.name as keyof typeof ERROR_HANDLERS] || ERROR_HANDLERS.defaultError;
+    ERROR_HANDLERS[error.name as keyof typeof ERROR_HANDLERS] ||
+    ERROR_HANDLERS.defaultError;
 
   handler(res, error);
 };


### PR DESCRIPTION
## Summary
- add generic `HttpError` class
- log and handle `HttpError` in error handler
- route controller error responses through `HttpError`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run tsc`

------
https://chatgpt.com/codex/tasks/task_e_684c42116cdc8326978057ed486593a2